### PR TITLE
!fix: draw children not working. Changes the way that draw override works.

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,10 +206,12 @@ the second uses `packingBias=3`._
 
 Subclassing the Layout class allows you to create pre-decorated layouts, which
 dynamically re-draw themselves.
-All you have to do is ensure that `Layout.__init__()` is called from your
-subclass's constructor method; and implement the default draw behaviour
- by overriding the `Layout.draw(self)` method, too.
- 
+Ensure that `Layout.__init__()` is called from your
+subclass's constructor method. Implement the default draw behaviour
+by overriding the `Layout.drawOverride(self)` method, too. Remember that this
+method is called after resizing, so you should be able to resize the
+information that you display at runtime.
+
     layout = new Layout()
     child = new DynamicLayout()  # your subclass, overrides `Layout.draw()`
     layout.addLayout(child)  # returns child, resized. will be auto-redrawn.

--- a/library/rpi_inky_layout/layout.py
+++ b/library/rpi_inky_layout/layout.py
@@ -345,10 +345,19 @@ class Layout:
         """Which slot this child starts in."""
         return self._getChildSlotCount(self.children[0:index])
 
+    def drawOverride(self):
+        """Override this method if you want to draw your own component.
+
+        Before this method is called (from the draw(self) method),
+        a new image is created, and the children are drawn.
+        """
+        return
+
     def draw(self):
+        self._drawChildren()
         if not self._image:
             self._image = Image.new(self.imageMode, self.size, self._depth)
-        self._drawChildren()
+        self.drawOverride()
 
         # draw the border
         draw = ImageDraw.Draw(self._image)
@@ -385,7 +394,7 @@ class Layout:
             ]
 
     def _drawChildren(self):
-        [child._drawChildren() for child in self.children]
+        [child.draw() for child in self.children]
         [
             self._drawChildOnParent(child, index)
             for index, child

--- a/library/test/test_issue_43.py
+++ b/library/test/test_issue_43.py
@@ -1,0 +1,63 @@
+import unittest
+from PIL import Image, ImageDraw
+
+from rpi_inky_layout import Layout
+
+
+def newImage(_size, backgroundcol):
+    img = Image.new("P", _size, backgroundcol)
+    img.putpalette((255, 255, 255, 0, 0, 0, 255, 0, 0) + (0, 0, 0) * 252)
+    return img
+
+
+class LayoutSub(Layout):
+
+    def __init__(self):
+        super().__init__((200, 200))
+
+    def drawOverride(self):
+
+        self._image = newImage(self.size, 0)
+        draw = ImageDraw.Draw(self._image)
+
+        def half_difference(x1, x2):
+            return int((x1 - x2) / 2)
+
+        text_x1, text_y1 = draw.textsize("LayoutSub")
+        text_x2, text_y2 = self.size
+        text_pos = (
+            half_difference(text_x2, text_x1),
+            half_difference(text_y2, text_y1)
+        )
+        draw.text(text_pos, "LayoutSub", fill=1)
+
+
+class TestIssue43(unittest.TestCase):
+
+    @staticmethod
+    def writeImage(layout, filename):
+        layout.write('test/expected-images/' + filename)
+
+    def testChildrenDraw(self):
+        layout = Layout((200, 200))
+        child = LayoutSub()
+        layout.addLayout(child)
+        otherChild = layout.addLayer(packingMode='v')
+        otherChild.addLayout(LayoutSub())
+        otherChild.addLayout(LayoutSub())
+        self.writeImage(layout, "testChildrenDraw.gif")
+
+    def testChildrenSetImage(self):
+        layout = Layout((200, 200))
+        child = LayoutSub()
+        otherChild = layout.addLayer(packingMode='v')
+        otherChild.addLayout(LayoutSub())
+        otherChild.addLayout(LayoutSub())
+        layout.addLayout(child)
+        img = child.draw()
+        child.setImage(img)
+        self.writeImage(layout, "testChildrenSetImage.gif")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
!fix: draw children not working. Changes the way that draw override works.